### PR TITLE
feat: add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+default:
+    @just --list
+
+alias b := build
+alias br := build-release
+alias f := fmt
+alias c := clean
+
+# variables
+
+elf-path := "./target/release/eq-program-keccak-inclusion"
+
+# Private just helper recipe
+_pre-build:
+    {{ if path_exists(elf-path) == "false" { `cargo b -r -p eq-program-keccak-inclusion` } else { "" } }}
+
+build: _pre-build
+    cargo b
+
+build-release: _pre-build
+    cargo b -r
+
+clean:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    cargo clean
+
+fmt:
+    @cargo fmt
+    @just --quiet --unstable --fmt > /dev/null

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 default:
     @just --list
 
+alias r := run
+alias rr := run-release
 alias b := build
 alias br := build-release
 alias f := fmt
@@ -13,6 +15,12 @@ elf-path := "./target/release/eq-program-keccak-inclusion"
 # Private just helper recipe
 _pre-build:
     {{ if path_exists(elf-path) == "false" { `cargo b -r -p eq-program-keccak-inclusion` } else { "" } }}
+
+run *FLAGS: build
+    cargo r -- {{FLAGS}}
+
+run-relese *FLAGS: build-release
+    cargo r -r -- {{FLAGS}}
 
 build: _pre-build
     cargo b

--- a/runner-keccak-inclusion/src/main.rs
+++ b/runner-keccak-inclusion/src/main.rs
@@ -1,19 +1,23 @@
-use sp1_sdk::{SP1Stdin, ProverClient};
-use std::fs;
-use eq_common::KeccakInclusionToDataRootProofInput;
 use celestia_types::nmt::NamespaceProof;
+use eq_common::KeccakInclusionToDataRootProofInput;
+use sp1_sdk::{ProverClient, SP1Stdin};
+use std::fs;
 
-const KECCAK_INCLUSION_ELF: &[u8] = include_bytes!("../../target/elf-compilation/riscv32im-succinct-zkvm-elf/release/eq-program-keccak-inclusion");
-
+const KECCAK_INCLUSION_ELF: &[u8] =
+    include_bytes!("../../target/release/eq-program-keccak-inclusion");
 
 fn main() {
     sp1_sdk::utils::setup_logger();
 
     let input_json = fs::read_to_string("proof_input.json").expect("Failed reading proof input");
-    let input: KeccakInclusionToDataRootProofInput = serde_json::from_str(&input_json).expect("Failed deserializing proof input");
+    let input: KeccakInclusionToDataRootProofInput =
+        serde_json::from_str(&input_json).expect("Failed deserializing proof input");
 
     let client = ProverClient::builder().cpu().build();
     let mut stdin = SP1Stdin::new();
     stdin.write(&input);
-    client.execute(KECCAK_INCLUSION_ELF, &stdin).run().expect("Failed executing program");
+    client
+        .execute(KECCAK_INCLUSION_ELF, &stdin)
+        .run()
+        .expect("Failed executing program");
 }


### PR DESCRIPTION
Mainly to build the workspace enforcing SP1 ELF is present, as if it's not, cargo build fails.

A followup PR will add a README section on how to [install](https://github.com/casey/just?tab=readme-ov-file#installation) and use `just`:

```sh
# one way to install just
cargo install just

# with just installed run:
just
# ^^ lists the commands

just b
# ^^ runs just build & a _pre-build recipe that checks for a required SP1 ELF file to build the project & generates iff needed
```


Opens the door to better devex in setting up, building, and deploying things from this repo.
