### PR TITLE
Progress on handling errors & retries

### DIFF
--- a/common/proto/eqservice.proto
+++ b/common/proto/eqservice.proto
@@ -5,23 +5,25 @@ service Inclusion {
     rpc GetKeccakInclusion(GetKeccakInclusionRequest) returns (GetKeccakInclusionResponse);
 }
 message GetKeccakInclusionRequest {
-    bytes commitment = 1;  // 32 byte blob commitment
-    bytes namespace = 2;   // 32 byte namespace
-    uint64 height = 3;     // block height
+    uint64 height = 1;     // Data Avaliblity block height
+    bytes namespace = 2;   // 32 byte DA namespace
+    bytes commitment = 3;  // 32 byte DA blob commitment
 }
 
 message GetKeccakInclusionResponse {
     enum Status {
-        WAITING = 0;
-        IN_PROGRESS = 1;
-        COMPLETE = 2;
-        FAILED = 3;
+        DA_PENDING = 0;        // Data Avaliblity (DA) inclusion proof being collected
+        DA_AVALIBLE = 1;       // DA inclusion proof collected
+        ZKP_PENDING = 2;       // Zero Knowledge Proof (ZKP) of DA inclusion requested, generating
+        ZKP_FINISHED = 3;      // ZKP of DA inclusion proof finished
+        RETRYABLE_FAILURE = 4; // If this is returned, the service then attempts to retry
+        PERMANENT_FAILURE = 5; // No way to complete request
     }
     Status status = 1;
     oneof response_value {
-        bytes proof_id = 2;    // Used when status is IN_PROGRESS, this is the proof id of the prover network
-        bytes proof = 3;        // Used when status is COMPLETE
-        string error_message = 4;       // Used when status is FAILED
-        string status_message = 5;       // Used when status is WAITING, this is the status message of the prover network
+        bytes proof_id = 2;        // When ZKP_PENDING, this is the proof request/job id on the prover network
+        bytes proof = 3;           // When ZKP_FINISHED, this is the proof data
+        string error_message = 4;  // Used when status is FAILED, this includes details why
+        string status_message = 5; // Additional details on status of a request
     }
 }

--- a/common/src/generated/eqs.rs
+++ b/common/src/generated/eqs.rs
@@ -2,15 +2,15 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetKeccakInclusionRequest {
-    /// 32 byte blob commitment
-    #[prost(bytes = "vec", tag = "1")]
-    pub commitment: ::prost::alloc::vec::Vec<u8>,
-    /// 32 byte namespace
+    /// Data Avaliblity block height
+    #[prost(uint64, tag = "1")]
+    pub height: u64,
+    /// 32 byte DA namespace
     #[prost(bytes = "vec", tag = "2")]
     pub namespace: ::prost::alloc::vec::Vec<u8>,
-    /// block height
-    #[prost(uint64, tag = "3")]
-    pub height: u64,
+    /// 32 byte DA blob commitment
+    #[prost(bytes = "vec", tag = "3")]
+    pub commitment: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -37,10 +37,18 @@ pub mod get_keccak_inclusion_response {
     )]
     #[repr(i32)]
     pub enum Status {
-        Waiting = 0,
-        InProgress = 1,
-        Complete = 2,
-        Failed = 3,
+        /// Data Avaliblity (DA) inclusion proof being collected
+        DaPending = 0,
+        /// DA inclusion proof collected
+        DaAvalible = 1,
+        /// Zero Knowledge Proof (ZKP) of DA inclusion requested, generating
+        ZkpPending = 2,
+        /// ZKP of DA inclusion proof finished
+        ZkpFinished = 3,
+        /// If this is returned, the service then attempts to retry
+        RetryableFailure = 4,
+        /// No way to complete request
+        PermanentFailure = 5,
     }
     impl Status {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -49,19 +57,23 @@ pub mod get_keccak_inclusion_response {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                Status::Waiting => "WAITING",
-                Status::InProgress => "IN_PROGRESS",
-                Status::Complete => "COMPLETE",
-                Status::Failed => "FAILED",
+                Status::DaPending => "DA_PENDING",
+                Status::DaAvalible => "DA_AVALIBLE",
+                Status::ZkpPending => "ZKP_PENDING",
+                Status::ZkpFinished => "ZKP_FINISHED",
+                Status::RetryableFailure => "RETRYABLE_FAILURE",
+                Status::PermanentFailure => "PERMANENT_FAILURE",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
-                "WAITING" => Some(Self::Waiting),
-                "IN_PROGRESS" => Some(Self::InProgress),
-                "COMPLETE" => Some(Self::Complete),
-                "FAILED" => Some(Self::Failed),
+                "DA_PENDING" => Some(Self::DaPending),
+                "DA_AVALIBLE" => Some(Self::DaAvalible),
+                "ZKP_PENDING" => Some(Self::ZkpPending),
+                "ZKP_FINISHED" => Some(Self::ZkpFinished),
+                "RETRYABLE_FAILURE" => Some(Self::RetryableFailure),
+                "PERMANENT_FAILURE" => Some(Self::PermanentFailure),
                 _ => None,
             }
         }
@@ -69,16 +81,16 @@ pub mod get_keccak_inclusion_response {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum ResponseValue {
-        /// Used when status is IN_PROGRESS, this is the proof id of the prover network
+        /// When ZKP_PENDING, this is the proof request/job id on the prover network
         #[prost(bytes, tag = "2")]
         ProofId(::prost::alloc::vec::Vec<u8>),
-        /// Used when status is COMPLETE
+        /// When ZKP_FINISHED, this is the proof data
         #[prost(bytes, tag = "3")]
         Proof(::prost::alloc::vec::Vec<u8>),
-        /// Used when status is FAILED
+        /// Used when status is FAILED, this includes details why
         #[prost(string, tag = "4")]
         ErrorMessage(::prost::alloc::string::String),
-        /// Used when status is WAITING, this is the status message of the prover network
+        /// Additional details on status of a request
         #[prost(string, tag = "5")]
         StatusMessage(::prost::alloc::string::String),
     }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -357,7 +357,10 @@ impl InclusionService {
                             }
                             Err(e) => {
                                 error!("{job:?} failed progressing DataAvalibile: {e}");
-                                job_status = JobStatus::Failed(e, None);
+                                job_status = JobStatus::Failed(
+                                    e,
+                                    Some(JobStatus::DataAvalibile(proof_input)),
+                                );
                                 self.finalize_job(&job_key, job_status)?;
                             }
                         };
@@ -373,7 +376,10 @@ impl InclusionService {
                             }
                             Err(e) => {
                                 error!("{job:?} failed progressing ZkProofPending: {e}");
-                                job_status = JobStatus::Failed(e, None);
+                                job_status = JobStatus::Failed(
+                                    e,
+                                    Some(JobStatus::ZkProofPending(zk_request_id)),
+                                );
                                 self.finalize_job(&job_key, job_status)?;
                             }
                         }


### PR DESCRIPTION
To try and make the service more robust to most error conditions, we retry on most errors when an incoming RPC call for a failed job comes in.