### PR TITLE
fix: dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Data Availability Equivalence Service
 
 A gRPC service acting as a "cryptographic adapter" providing proofs that data (a blob) exists on [Celestia](https://celestia.org/) that are efficiently verifiable on EVM networks.
-A [Namespace Merkle Tree (NMT)](https://celestia.org/glossary/namespaced-merkle-tree/) proof is transformed via a [Zero Knowledge Proof (ZKP)](https://docs.succinct.xyz/docs/what-is-a-zkvm) into a keccak hash check.
+A [Namespace Merkle Tree (NMT)](https://celestia.org/glossary/namespaced-merkle-tree/) proof is transformed via a [Zero Knowledge Proof (ZKP)](https://docs.succinct.xyz/docs/sp1/what-is-a-zkvm) into a keccak hash check.
 
 A few key features:
 
@@ -45,7 +45,7 @@ The service **_requires_** a connection to:
    - Fetch blob data.
    - Get headers.
    - Retrieve Merkle tree proofs for blobs.
-1. [Succinct's prover network](https://docs.succinct.xyz/docs/generating-proofs/prover-network) as a provider to generate Zero-Knowledge Proofs (ZKPs) of data existing on Celestia.
+1. [Succinct's prover network](https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network) as a provider to generate Zero-Knowledge Proofs (ZKPs) of data existing on Celestia.
    _See the [ZKP program](./program-keccak-inclusion/src/main.rs) for details on what is proven._
 
 ## Interact
@@ -111,7 +111,7 @@ Most users will want to pull and run this service via the [container registry](#
      - Succinct prover network over `443`
    - **NOTE:** These requirements may be significantly more to respond under heavy load, please report if you have issues!
 
-1. A whitelisted key in your `env` for use with the Succinct prover network Key - [requested here](https://docs.succinct.xyz/docs/generating-proofs/prover-network).
+1. A whitelisted key in your `env` for use with the Succinct prover network Key - [requested here](https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network).
 
 1. A Celestia Light Node [installed](https://docs.celestia.org/how-to-guides/celestia-node) & [running](https://docs.celestia.org/tutorials/node-tutorial#auth-token) accessible on `localhost`, or elsewhere.
    Alternatively, use [an RPC provider](https://github.com/celestiaorg/awesome-celestia/?tab=readme-ov-file#node-operator-contributions) you trust.
@@ -158,7 +158,7 @@ The images are built and published for [releases](https://github.com/celestiaorg
 First, some tooling is required:
 
 1. Rust & Cargo - [install instructions](https://www.rust-lang.org/tools/install)
-1. Succinct's SP1 zkVM Toolchain - [install instructions](https://docs.succinct.xyz/docs/getting-started/install)
+1. Succinct's SP1 zkVM Toolchain - [install instructions](https://docs.succinct.xyz/docs/sp1/getting-started/install)
 1. Protocol Buffers (Protobuf) compiler - [official examples](https://github.com/hyperium/tonic/tree/master/examples#examples) contain install instructions
 1. (Optional) Just - a modern alternative to `make` [installed](https://just.systems/man/en/packages.html)
 

--- a/example.env
+++ b/example.env
@@ -30,5 +30,5 @@ EQ_PROTO_DIR=./common/proto
 
 # For using the SP1 Prover network
 # More info & request getting on the white list:
-# https://docs.succinct.xyz/docs/generating-proofs/prover-network
+# https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network
 NETWORK_PRIVATE_KEY=succinct-luvs-u 

--- a/service/src/internal/util.rs
+++ b/service/src/internal/util.rs
@@ -5,7 +5,7 @@ use tokio::signal::{
     unix::{signal as unix_signal, SignalKind},
 };
 /// A Succinct Prover Network request ID.
-/// See: https://docs.succinct.xyz/docs/generating-proofs/prover-network/usage
+/// See: https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/usage
 pub type SuccNetJobId = [u8; 32];
 
 /// A SHA3 256 bit hash of a zkVM program's ELF.


### PR DESCRIPTION
Hi! I updates dead links in the following files:

- README.md
- util.rs
- example.env

The links were pointing to outdated URLs related to Succinct's documentation.