### PR TITLE
fix: fixincorrect status reference in GetKeccakInclusionResponse comment

### DIFF
--- a/common/proto/eqservice.proto
+++ b/common/proto/eqservice.proto
@@ -4,6 +4,7 @@ package eqs;
 service Inclusion {
     rpc GetKeccakInclusion(GetKeccakInclusionRequest) returns (GetKeccakInclusionResponse);
 }
+
 message GetKeccakInclusionRequest {
     uint64 height = 1;             // Data Availability (DA) block height
     bytes namespace = 2;           // 32 byte DA namespace
@@ -23,7 +24,7 @@ message GetKeccakInclusionResponse {
     oneof response_value {
         bytes proof_id = 2;        // When ZKP_PENDING, this is the proof request/job id on the prover network
         bytes proof = 3;           // When ZKP_FINISHED, this is the proof data
-        string error_message = 4;  // Used when status is FAILED, this includes details why
+        string error_message = 4;  // Used when status is RETRYABLE_FAILURE or PERMANENT_FAILURE, this includes details why
         string status_message = 5; // Additional details on status of a request
     }
 }


### PR DESCRIPTION
## Overview
I’ve updated the comment in the `GetKeccakInclusionResponse` message. It previously mentioned "FAILED" as a status, but the correct options from the `Status` enum are "RETRYABLE_FAILURE" and "PERMANENT_FAILURE." The comment has been revised to accurately reflect the available statuses.
