### PR TITLE
no `*` deps allowed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ log = "0.4"
 base64 = "0.22"
 jsonrpsee = "0.24"
 alloy = { version = "0.9", default-features = false }
-alloy-primitives = "*"
-alloy-sol-types = "*"
+alloy-primitives = "0.8"
+alloy-sol-types = "0.8"
 
 [patch.crates-io]
 sha3-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", branch = "patch-sha3-v0.10.8" }


### PR DESCRIPTION
cannot publish on crates.io with any loose versions
