### PR TITLE
Fix: timeout for proof requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ grpcurl -import-path $EQ_PROTO_DIR -proto eqservice.proto \
 grpcurl -import-path $EQ_PROTO_DIR -proto eqservice.proto \
   -d '{"height": 4499999, "namespace": "Ucwac9Zflfa95g==", "commitment":"S2iIifIPdAjQ33KPeyfAga26FSF3IL11WsCGtJKSOTA="}' \
   -plaintext $EQ_SOCKET eqs.Inclusion.GetKeccakInclusion
+
+# https://mocha.celenium.io/tx/36797fdd1faa19ef8df1a3d3ec1b0278eb784b0a8cc3d5cd94db10b254f3eb78
+grpcurl -import-path $EQ_PROTO_DIR -proto eqservice.proto \
+  -d '{"height": 6692080, "namespace": "XSUTEfJbE6VJ4A==", "commitment":"iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4="}' \
+  plaintext $EQ_SOCKET eqs.Inclusion.GetKeccakInclusion
+
 ```
 
 ## Operate

--- a/blob-tool/src/main.rs
+++ b/blob-tool/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     let args = Args::parse();
 
     let node_token = std::env::var("CELESTIA_NODE_AUTH_TOKEN").expect("Token not provided");
-    let client = Client::new("ws://localhost:26658", Some(&node_token))
+    let client = Client::new("http://127.0.0.1:26658", Some(&node_token))
         .await
         .expect("Failed creating celestia rpc client");
 

--- a/example.env
+++ b/example.env
@@ -30,5 +30,6 @@ EQ_PROTO_DIR=./common/proto
 
 # For using the SP1 Prover network
 # More info & request getting on the white list:
-# <https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network>
-NETWORK_PRIVATE_KEY=succinct-luvs-u 
+# <https://docs.succinct.xyz/docs/network/developers/request-proofs>
+NETWORK_PRIVATE_KEY=0xyour-64char-hex-private-key-000000000000000000000000000000000000
+PROOF_GEN_TIMEOUT_SECONDS=120

--- a/sdk/examples/README.md
+++ b/sdk/examples/README.md
@@ -11,7 +11,7 @@ These typically require a running [eq-service](../../service) instance , see the
 set -a
 source ../.env
 
-# https://mocha.celenium.io/tx/c3c301fe579feb908fe02e2e8549c38f23707d30a3d4aa73e26402d854ff9104
-# "height": 4409088, "namespace": "XSUTEfJbE6VJ4A==", "commitment":"DYoAZpU7FrviV7Ui/AjQv0BpxCwexPWaOW/hQVpEl/s="
-cargo run --example client -- --socket $EQ_SOCKET --height 4409088 --namespace XSUTEfJbE6VJ4A== --commitment DYoAZpU7FrviV7Ui/AjQv0BpxCwexPWaOW/hQVpEl/s=
+# https://mocha.celenium.io/tx/436f223bfa8c4adf1e1b79dde43a84918f3a50809583c57c33c1c079568b47cb
+# "height": 6608695, "namespace": "C8EGyFVBxOL3bA==", "commitment":"nPDyRXefks+koMJhy7LzN9269+Oz4PjcsAPk64ke85E="
+cargo run --example client -- --socket $EQ_SOCKET --height 6608695 --namespace C8EGyFVBxOL3bA== --commitment nPDyRXefks+koMJhy7LzN9269+Oz4PjcsAPk64ke85E=
 ```

--- a/service/src/internal/inclusion.rs
+++ b/service/src/internal/inclusion.rs
@@ -71,7 +71,8 @@ impl InclusionService {
 
 pub struct InclusionServiceConfig {
     pub da_node_token: String,
-    pub da_node_ws: String,
+    pub da_node_http: String,
+    pub zk_proof_gen_timeout: Duration,
 }
 
 impl InclusionService {
@@ -147,7 +148,7 @@ impl InclusionService {
                 }
                 JobStatus::ZkProofPending(zk_request_id) => {
                     debug!("ZK request waiting");
-                    match self.wait_for_zk_proof(&job_key, zk_request_id).await {
+                    match self.wait_for_zk_proof(&job, &job_key, zk_request_id).await {
                         Ok(zk_proof) => {
                             info!("🎉 {job:?} Finished!");
                             job_status = JobStatus::ZkProofFinished(zk_proof);
@@ -387,13 +388,13 @@ impl InclusionService {
             }
             SP1NetworkError::RequestUnfulfillable { .. } => {
                 e = InclusionServiceError::DaClientError(format!(
-                    "ZKP network failure: {zk_client_error} occurred  for {job:?} PLEASE REPORT!"
+                    "ZKP network failure: {zk_client_error} occurred for {job:?} PLEASE REPORT!"
                 ));
                 job_status = JobStatus::Failed(e.clone(), None);
             }
             SP1NetworkError::RequestTimedOut { request_id } => {
                 e = InclusionServiceError::DaClientError(format!(
-                    "ZKP network: {zk_client_error} occurred  for {job:?}"
+                    "ZKP network: {zk_client_error} occurred for {job:?}"
                 ));
 
                 let id = request_id
@@ -405,7 +406,7 @@ impl InclusionService {
             }
             SP1NetworkError::RpcError(_) | SP1NetworkError::Other(_) => {
                 e = InclusionServiceError::DaClientError(format!(
-                    "ZKP network failure: {zk_client_error} occurred  for {job:?} PLEASE REPORT!"
+                    "ZKP network failure: {zk_client_error} occurred for {job:?} PLEASE REPORT!"
                 ));
                 // TODO: We cannot clone KeccakInclusionToDataRootProofInput thus we cannot insert into a JobStatus::DataAvailable(proof_input)
                 // So we just redo the work from scratch for the DA side as a stupid workaround
@@ -439,7 +440,7 @@ impl InclusionService {
             .prove(&proof_setup.pk, &stdin)
             .groth16()
             .skip_simulation(false)
-            .timeout(Duration::from_secs(5)) // Don't hang too long on this. If it's gonna fail, fail fast.
+            .timeout(self.config.zk_proof_gen_timeout)
             .request_async()
             .await
             // TODO: how to handle errors without a concrete type? Anyhow is not the right thing for us...
@@ -447,6 +448,7 @@ impl InclusionService {
                 if let Some(down) = e.downcast_ref::<SP1NetworkError>() {
                     return self.handle_zk_client_error(down, job, job_key);
                 }
+                error!("UNHANDLED ZK client error: {e:?}");
                 InclusionServiceError::ZkClientError(format!("Unhandled Error: {e} PLEASE REPORT"))
             })?
             .into();
@@ -457,6 +459,7 @@ impl InclusionService {
     /// Await a proof request from Succinct's prover network
     async fn wait_for_zk_proof(
         &self,
+        job: &Job,
         job_key: &[u8],
         request_id: SuccNetJobId,
     ) -> Result<SP1ProofWithPublicValues, InclusionServiceError> {
@@ -467,21 +470,13 @@ impl InclusionService {
             .wait_proof(request_id.into(), None)
             .await
             .map_err(|e| {
-                error!("UNHANDLED ZK client error: {e:?}");
-                let e = InclusionServiceError::ZkClientError(
-                    "UNKNOWN ZK client error. PLEASE REPORT!".to_string(),
-                );
-                match self.finalize_job(
-                    job_key,
-                    JobStatus::Failed(
-                        e.clone(),
-                        Some(JobStatus::ZkProofPending(request_id).into()),
-                    ),
-                ) {
-                    Ok(_) => e,
-                    Err(internal_err) => internal_err,
+                if let Some(down) = e.downcast_ref::<SP1NetworkError>() {
+                    return self.handle_zk_client_error(down, job, job_key);
                 }
+                error!("UNHANDLED ZK client error: {e:?}");
+                InclusionServiceError::ZkClientError(format!("Unhandled Error: {e} PLEASE REPORT"))
             })?;
+
         Ok(proof)
     }
 
@@ -540,7 +535,7 @@ impl InclusionService {
             .get_or_try_init(|| async {
                 debug!("Building DA client");
                 let client = CelestiaJSONClient::new(
-                    self.config.da_node_ws.as_str(),
+                    self.config.da_node_http.as_str(),
                     self.config.da_node_token.as_str().into(),
                 )
                 .await

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -9,6 +9,7 @@ use internal::util::*;
 
 use log::{debug, error, info};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, OnceCell};
 use tonic::transport::Server;
 
@@ -20,7 +21,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("NETWORK_PRIVATE_KEY for Succinct Prover env var required");
     let da_node_token = std::env::var("CELESTIA_NODE_AUTH_TOKEN")
         .expect("CELESTIA_NODE_AUTH_TOKEN env var required");
-    let da_node_ws =
+    let zk_proof_gen_timeout = Duration::from_secs(
+        std::env::var("PROOF_GEN_TIMEOUT_SECONDS")
+            .expect("PROOF_GEN_TIMEOUT_SECONDS env var required")
+            .parse()
+            .expect("PROOF_GEN_TIMEOUT_SECONDS must be integer"),
+    );
+    let da_node_http =
         std::env::var("CELESTIA_NODE_HTTP").expect("CELESTIA_NODE_HTTP env var required");
     let db_path = std::env::var("EQ_DB_PATH").expect("EQ_DB_PATH env var required");
     let service_socket: std::net::SocketAddr = std::env::var("EQ_SOCKET")
@@ -38,7 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let inclusion_service = Arc::new(InclusionService::new(
         InclusionServiceConfig {
             da_node_token,
-            da_node_ws,
+            da_node_http,
+            zk_proof_gen_timeout,
         },
         OnceCell::new(),
         OnceCell::new(),


### PR DESCRIPTION
New env `PROOF_GEN_TIMEOUT_SECONDS` set to an integer (u64) - default suggested 120 seconds (should be way overkill)

tested with https://mocha.celenium.io/tx/36797fdd1faa19ef8df1a3d3ec1b0278eb784b0a8cc3d5cd94db10b254f3eb78

https://network.succinct.xyz/request/0xfbfc84b631f536ef0501d857d90cea25e7c573bfa9202441093efb055bfc71d5 took 18 seconds.

Trying with 1 second timeout:

```
Received grpc request for: Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
New Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } sending to worker and adding to queue
Job worker received Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
Job worker processing with starting status: DataAvailabilityPending
Preparing request to Celestia
Creating ZK Proof input from Celestia Data
Sending Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } back with updated status: DataAvailable
DA data -> zk input ready
Job worker received Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
Job worker processing with starting status: DataAvailable
Preparing prover network request and starting proving
Getting ZK program proof setup
UNHANDLED ZK client error: status: InvalidArgument, message: "min auction period 0 is greater than the deadline 1750355220", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Thu, 19 Jun 2025 17:47:05 GMT", "content-type": "application/grpc", "content-length": "0", "set-cookie": "AWSALBAPP-0=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-1=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-2=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-3=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "access-control-expose-headers": "grpc-status,grpc-message", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-credentials": "true"} }
Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } failed progressing DataAvailable: Unhandled Error: status: InvalidArgument, message: "min auction period 0 is greater than the deadline 1750355220", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Thu, 19 Jun 2025 17:47:05 GMT", "content-type": "application/grpc", "content-length": "0", "set-cookie": "AWSALBAPP-0=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-1=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-2=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "set-cookie": "AWSALBAPP-3=_remove_; Expires=Thu, 26 Jun 2025 17:47:05 GMT; Path=/", "access-control-expose-headers": "grpc-status,grpc-message", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-credentials": "true"} } PLEASE REPORT
ZK request sent

------------------------

Received grpc request for: Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
Job is Retryable Failure, returning status & retrying
Sending Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } back with updated status: DataAvailable
Job worker received Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
Job worker processing with starting status: DataAvailable
Preparing prover network request and starting proving
Getting ZK program proof setup
Sending Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } back with updated status: ZkProofPending
ZK request sent
Job worker received Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
Job worker processing with starting status: ZkProofPending
ZK request waiting
Waiting for proof from prover network
SP1 Client error: Proof request 0xaecb306338f69e3c84e47dc82dac3d4e685ea79f3ad3b3a084c1c89df8e93d39 timed out
Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" } failed progressing ZkProofPending: ZKP network: Proof request 0xaecb306338f69e3c84e47dc82dac3d4e685ea79f3ad3b3a084c1c89df8e93d39 timed out occurred for Job { height: 6692080, namespace: "XSUTEfJbE6VJ4A==", commitment: "iu5d9b+rtl5B/j2ju3hUqbJT0y/kcUV4gHUdCvU2Jn4=" }
```

notice the first error (that seems to trigger randomly... we can follow up with better handling latter if needed) we can retry.

If retry-able, the same grpc call will ***restart a timed out zk proof job from scratch***. So we make a whole new job, rather than get stuck trying to wait on a timed out job. 