### PR TITLE
[audit] fix for h-02

### DIFF
--- a/blob-tool/src/main.rs
+++ b/blob-tool/src/main.rs
@@ -87,6 +87,8 @@ async fn main() {
         row_proof: range_response.clone().proof.row_proof,
         data_root: header.dah.hash().as_bytes().try_into().unwrap(),
         keccak_hash: keccak_hash,
+        batch_number: 0,
+        chain_id: 0,
     };
 
     // create a ShareProof from the KeccakInclusionToDataRootProofInput and verify it

--- a/common/proto/eqservice.proto
+++ b/common/proto/eqservice.proto
@@ -9,6 +9,8 @@ message GetKeccakInclusionRequest {
     uint64 height = 1;             // Data Availability (DA) block height
     bytes namespace = 2;           // 32 byte DA namespace
     bytes commitment = 3;          // 32 byte DA blob commitment
+    uint32 batch_number = 4;
+    uint64 chain_id = 5;
 }
 
 message ProofWithPublicValues {

--- a/common/src/generated/eqs.rs
+++ b/common/src/generated/eqs.rs
@@ -11,6 +11,10 @@ pub struct GetKeccakInclusionRequest {
     /// 32 byte DA blob commitment
     #[prost(bytes = "vec", tag = "3")]
     pub commitment: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "4")]
+    pub batch_number: u32,
+    #[prost(uint64, tag = "5")]
+    pub chain_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/program-keccak-inclusion/src/main.rs
+++ b/program-keccak-inclusion/src/main.rs
@@ -51,6 +51,8 @@ pub fn main() {
     let output: Vec<u8> = KeccakInclusionToDataRootProofOutput {
         keccak_hash: computed_keccak_hash,
         data_root: input.data_root,
+        batch_number: input.batch_number,
+        chain_id: input.chain_id,
     }
     .to_vec();
     sp1_zkvm::io::commit_slice(&output);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -36,6 +36,8 @@ impl EqClient {
                     .ok_or(TonicStatus::invalid_argument("Namespace invalid"))?
                     .to_vec(),
                 height: request.height.into(),
+                batch_number: request.batch_number,
+                chain_id: request.l2_chain_id,
             };
             let mut client = InclusionClient::new(self.grpc_channel.clone());
             match client.get_keccak_inclusion(request).await {

--- a/service/src/internal/grpc.rs
+++ b/service/src/internal/grpc.rs
@@ -35,6 +35,8 @@ impl Inclusion for InclusionServiceArc {
             Commitment::new(request.commitment.try_into().map_err(|_| {
                 Status::invalid_argument("Commitment must be 32 bytes, check encoding")
             })?),
+            request.chain_id,
+            request.batch_number,
         );
 
         info!("Received grpc request for: {job:?}");

--- a/service/src/internal/inclusion.rs
+++ b/service/src/internal/inclusion.rs
@@ -276,6 +276,8 @@ impl InclusionService {
                 )
             })?,
             keccak_hash,
+            batch_number: job.batch_number,
+            chain_id: job.l2_chain_id,
         };
 
         self.send_job_with_new_status(


### PR DESCRIPTION
For issue H-02 in the audit, it was recommended that we utilize the `chain_id` and `batch_number` fields from ZKSync's data availability interface to prevent _proof replay_.

This PR affects the whole repo, since it adds the chain_id and batch_number to the gRPC request type, the service, and the proof program itself.