### PR TITLE
restore linux-related imports

### DIFF
--- a/service/src/internal/util.rs
+++ b/service/src/internal/util.rs
@@ -1,6 +1,9 @@
 use log::info;
 use serde::{Deserialize, Serialize};
-use tokio::signal::{self};
+use tokio::signal::{
+    self,
+    unix::{signal as unix_signal, SignalKind},
+};
 /// A Succinct Prover Network request ID.
 /// See: <https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/usage>
 pub type SuccNetJobId = [u8; 32];

--- a/service/src/internal/util.rs
+++ b/service/src/internal/util.rs
@@ -1,9 +1,9 @@
 use log::info;
 use serde::{Deserialize, Serialize};
-use tokio::signal::{
-    self,
-    unix::{signal as unix_signal, SignalKind},
-};
+use tokio::signal::{self};
+#[cfg(target_os = "linux")]
+use tokio::signal::unix::{signal as unix_signal, SignalKind};
+
 /// A Succinct Prover Network request ID.
 /// See: <https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/usage>
 pub type SuccNetJobId = [u8; 32];


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Whoops I accidentally deleted some imports that appeared unused because I'm on a Mac, but are necessary to build the server for linux. This PR restores 

Hide unused imports warnings on Mac with a `cfg`