### PR TITLE
chore: clean up clippy warnings

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -127,8 +127,8 @@ pub fn compute_share_raw_data_keccak(
 
     // 2) Full continuation shares in the middle (and optionally the last if full)
     let full_end = if last_full { n } else { n - 1 };
-    for i in 1..full_end {
-        let si = raw_shares[i].as_ref();
+    for si in raw_shares.iter().take(full_end).skip(1) {
+        let si = si.as_ref();
         let endi = off_cont + CONTINUATION_SPARSE_SHARE_CONTENT_SIZE;
         hasher.update(&si[off_cont..endi]);
     }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -18,6 +18,7 @@ impl EqClient {
     pub fn new(grpc_channel: Channel) -> Self {
         Self { grpc_channel }
     }
+    #[allow(clippy::manual_async_fn)]
     pub fn get_zk_stack<'a>(
         &'a self,
         request: &'a JobId,
@@ -39,10 +40,8 @@ impl EqClient {
                 chain_id: request.l2_chain_id,
             };
             let mut client = InclusionClient::new(self.grpc_channel.clone());
-            match client.get_zk_stack(request).await {
-                Ok(response) => Ok(response.into_inner()),
-                Err(e) => Err(e),
-            }
+            let response = client.get_zk_stack(request).await?;
+            Ok(response.into_inner())
         }
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -81,7 +81,7 @@ impl std::fmt::Debug for BlobId {
             "Invalid v0 ID".to_string()
         };
         let commitment_string =
-            base64::engine::general_purpose::STANDARD.encode(&self.commitment.hash());
+            base64::engine::general_purpose::STANDARD.encode(self.commitment.hash());
         f.debug_struct("BlobId")
             .field("height", &self.height.value())
             .field("namespace", &namespace_string)
@@ -99,7 +99,7 @@ impl Display for BlobId {
             "Invalid v0 ID".to_string()
         };
         let commitment_string =
-            base64::engine::general_purpose::STANDARD.encode(&self.commitment.hash());
+            base64::engine::general_purpose::STANDARD.encode(self.commitment.hash());
         write!(
             f,
             "{}:{}:{}",
@@ -135,7 +135,7 @@ impl FromStr for BlobId {
         let c_hash: [u8; 32] = c_bytes
             .try_into()
             .map_err(|_| "Commitment must be 32 bytes!")?;
-        let commitment = Commitment::new(c_hash.into());
+        let commitment = Commitment::new(c_hash);
 
         Ok(Self {
             height,


### PR DESCRIPTION
Fixes minor clippy warnings in common and sdk crates